### PR TITLE
Move the password validation server side

### DIFF
--- a/controllers/authentication.js
+++ b/controllers/authentication.js
@@ -1,0 +1,10 @@
+const PASSWORD = process.env.PASSWORD;
+
+exports.validatePassword = (req, res) => {
+  const { password } = req.body;
+  if (password === PASSWORD) {
+    res.status(200).json({ success: true });
+  } else {
+    res.status(401).json({ success: false });
+  }
+};

--- a/frontend/src/screen/Home/AdminLogin.jsx
+++ b/frontend/src/screen/Home/AdminLogin.jsx
@@ -1,14 +1,20 @@
 import React, { useState } from "react";
 import users from "../../data/users.json";
-import dotenv from "dotenv";
+import axios from "axios";
 
 import "./AdminLogin.scss";
 
 const AdminLogin = ({ closeHandler, showAlert }) => {
   const [adminPassword, setAdminPassword] = useState("");
-  dotenv.config();
-  const validateAdminPasswordInput = () => {
-    if (adminPassword.trim() === process.env.REACT_APP_Password) {
+
+  const validateAdminPasswordInput = async () => {
+    const {
+      data: { success },
+    } = await axios.post("/api/v1/authentication/login", {
+      password: adminPassword.trim(),
+    });
+
+    if (success) {
       closeHandler();
       showAlert("success", "The security code has been verified successfully.");
       setTimeout(() => {

--- a/routes/authentication.js
+++ b/routes/authentication.js
@@ -1,0 +1,7 @@
+const express = require("express");
+const router = express.Router();
+const { validatePassword } = require("../controllers/authentication");
+
+router.route("/login").post(validatePassword);
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -12,7 +12,8 @@ app.use(express.json());
 
 app.use("/api/v1/classes", require("./routes/classes"));
 app.use("/api/v1/bookings", require("./routes/bookings"));
-app.use("/api/v1/courses", require("./routes/courseCalendar")); 
+app.use("/api/v1/courses", require("./routes/courseCalendar"));
+app.use("/api/v1/authentication", require("./routes/authentication"));
 
 if (process.env.NODE_ENV === "production") {
   app.use(express.static("frontend/build"));


### PR DESCRIPTION
As a volunteer, I'm not totally comfortable with the way in which authentication is currently handled on the front-end. The password is hard-coded into the frontend and is visible and easy to access by viewing the source code, which then reveals the email addresses of all the volunteers.

As there's already a backend integration for this app, it would be better to store the password as an ENV variable to make it easier to change in the future, and so that it can't be read from the frontend.

This is an example of how this logic could be integrated, however this was done without a DB connection so there may be errors. 